### PR TITLE
feat(android): update library

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,4 +1,4 @@
 
 dependencies {
-	implementation 'androidx.browser:browser:1.2.0'
+	implementation 'androidx.browser:browser:1.4.0'
 }

--- a/android/manifest
+++ b/android/manifest
@@ -2,7 +2,7 @@
 # this is your module manifest and used by Titanium
 # during compilation, packaging, distribution, etc.
 #
-version: 2.0.0
+version: 2.1.0
 apiversion: 4
 architectures: arm64-v8a armeabi-v7a x86 x86_64
 description: titanium-web-dialog

--- a/android/src/ti/webdialog/TitaniumWebDialogModule.java
+++ b/android/src/ti/webdialog/TitaniumWebDialogModule.java
@@ -17,7 +17,6 @@ import android.graphics.drawable.BitmapDrawable;
 import android.graphics.drawable.Drawable;
 import android.net.Uri;
 import android.util.DisplayMetrics;
-
 import androidx.browser.customtabs.CustomTabColorSchemeParams;
 import androidx.browser.customtabs.CustomTabsIntent;
 import androidx.browser.customtabs.CustomTabsService;
@@ -67,9 +66,8 @@ public class TitaniumWebDialogModule extends KrollModule
 
 		int barColor = Utils.getColor(options, Params.BAR_COLOR);
 		if (barColor != -1) {
-			CustomTabColorSchemeParams params = new CustomTabColorSchemeParams.Builder()
-					.setToolbarColor(barColor)
-					.build();
+			CustomTabColorSchemeParams params =
+				new CustomTabColorSchemeParams.Builder().setToolbarColor(barColor).build();
 			builder.setDefaultColorSchemeParams(params);
 		}
 

--- a/android/src/ti/webdialog/TitaniumWebDialogModule.java
+++ b/android/src/ti/webdialog/TitaniumWebDialogModule.java
@@ -17,6 +17,8 @@ import android.graphics.drawable.BitmapDrawable;
 import android.graphics.drawable.Drawable;
 import android.net.Uri;
 import android.util.DisplayMetrics;
+
+import androidx.browser.customtabs.CustomTabColorSchemeParams;
 import androidx.browser.customtabs.CustomTabsIntent;
 import androidx.browser.customtabs.CustomTabsService;
 import java.util.ArrayList;
@@ -65,7 +67,10 @@ public class TitaniumWebDialogModule extends KrollModule
 
 		int barColor = Utils.getColor(options, Params.BAR_COLOR);
 		if (barColor != -1) {
-			builder.setToolbarColor(barColor);
+			CustomTabColorSchemeParams params = new CustomTabColorSchemeParams.Builder()
+					.setToolbarColor(barColor)
+					.build();
+			builder.setDefaultColorSchemeParams(params);
 		}
 
 		// set start and exit animations
@@ -76,12 +81,12 @@ public class TitaniumWebDialogModule extends KrollModule
 
 		// hide navigation bar on scroll
 		if (Utils.getBool(options, Params.BAR_COLLAPSING_ENABLED)) {
-			builder.enableUrlBarHiding();
+			builder.setUrlBarHidingEnabled(true);
 		}
 
 		//enable Share link option
 		if (Utils.getBool(options, Params.ENABLE_SHARING)) {
-			builder.addDefaultShareMenuItem();
+			builder.setShareState(CustomTabsIntent.SHARE_STATE_ON);
 		}
 
 		String closeIcon = Utils.getString(options, Params.CLOSE_ICON);

--- a/android/src/ti/webdialog/Utils.java
+++ b/android/src/ti/webdialog/Utils.java
@@ -47,7 +47,7 @@ public class Utils
 	// return the list of all available & enabled browsers in device
 	public static List<ResolveInfo> allBrowsers(Context context)
 	{
-		Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse("http://www.testingurl.com"));
+		Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse("https://localhost"));
 		return context.getPackageManager().queryIntentActivities(intent, 0);
 	}
 

--- a/android/timodule.xml
+++ b/android/timodule.xml
@@ -1,11 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ti:module xmlns:ti="http://ti.appcelerator.org" xmlns:android="http://schemas.android.com/apk/res/android">
-	<!--
-		Similar to tiapp.xml, but contains module/platform specific
-		configuration in <iphone>, <android>, and <mobileweb> sections
-	-->
-	<iphone>
-	</iphone>
+	<!-- Similar to tiapp.xml, but contains module/platform specific configuration in <iphone>, <android>, and <mobileweb> sections -->
+	<iphone></iphone>
 	<android xmlns:android="http://schemas.android.com/apk/res/android">
+		<manifest>
+			<queries>
+				<intent>
+					<action android:name="android.intent.action.VIEW"/>
+					<data android:scheme="http"/>
+				</intent>
+			</queries>
+		</manifest>
 	</android>
 </ti:module>


### PR DESCRIPTION
* updated the dependencies to https://developer.android.com/jetpack/androidx/releases/browser#version_140_3 for Android 12 fix `mark PendingIntents as PendingIntent.FLAG_IMMUTABLE for Android 12 compatibility`
* changed deprecated methods
* changed URL
* added `<queries>` so it will find the installed browsers

[ti.webdialog-android-2.1.0.zip](https://github.com/appcelerator-modules/titanium-web-dialog/files/7587383/ti.webdialog-android-2.1.0.zip)


Related #173 