### PR TITLE
parity: android close event

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ Use the native `SFSafariViewController` (iOS) and `Chrome Pages` (Android) withi
 The iOS part of this module is based on Ti.SafariDialog, which has been deprecated for a cross-platform solution. All API's of Ti.SafariDialog
 still work here and have been extended by more features over time.
 
+## Android Note
+In order to use the `close` event on Android it is recommended to have a short delay between `var WebDialog = require('ti.webdialog');` and `WebDialog.open({})`. Otherwise it might not fire the `close` event.
+
 ## API's
 
 ### Top-Level

--- a/README.md
+++ b/README.md
@@ -1,23 +1,18 @@
 # Titanium Web Dialog
 
-Use the native `SFSafariViewController` (iOS) and `Chrome Pages` (Android) within Axway Titanium. 
+Use the native `SFSafariViewController` (iOS) and `Chrome Pages` (Android) within Appcelerator Titanium.
 
 <img src="./fixtures/example-screens.jpg" width="890" alt="Titanium Web Dialog" />
 
 ## Requirements
 
-- Titanium SDK 7.0.0 or later (or use the [SDK-6-compatibility](https://github.com/appcelerator-modules/titanium-web-dialog/tree/SDK-6-compatibility) Titanium SDK 6.x)
+- Titanium SDK 9.0.0 or later
 - iOS 9+ and Android 4.1+
 
 ## iOS Note
 
 The iOS part of this module is based on Ti.SafariDialog, which has been deprecated for a cross-platform solution. All API's of Ti.SafariDialog
 still work here and have been extended by more features over time.
-
-## Android Legacy Support
-
-This module is designed to work with the latest platform API's that are covered by the Titanium SDK 7.0.0 and later.
-If you want to use this module in Titanium SDK 6.x, please use the [this version](https://github.com/appcelerator-modules/titanium-web-dialog/raw/SDK-6-compatibility/android/legacy/ti.webdialog-android-1.0.0.zip).
 
 ## API's
 
@@ -38,7 +33,7 @@ If you want to use this module in Titanium SDK 6.x, please use the [this version
     * `fadeTransition` (Boolean, Android only)
     * `enableSharing` (Boolean, Android only) - Enable Share... menu item to share link
     * `closeIcon` (String, Android only) - image path to show as close-button icon
-  
+
 * `isSupported()` -> Boolean
 * `isOpen()` (iOS only) -> Boolean
 * `close()` (iOS only)
@@ -52,7 +47,7 @@ If you want to use this module in Titanium SDK 6.x, please use the [this version
 #### Events
 
 * `open` -> `success` (Boolean), `url` (String)
-* `close` -> `success` (Boolean), `url` (String) - iOS only
+* `close` -> `success` (Boolean), `url` (String)
 * `load` -> `success` (Boolean), `url` (String) - iOS only
 * `redirect` -> `url` (String) - iOS only
 
@@ -62,7 +57,7 @@ If you want to use this module in Titanium SDK 6.x, please use the [this version
 
 * `createAuthenticationSession(arguments)`
     * `url` (String)
-    * `scheme` (String) 
+    * `scheme` (String)
 
 #### Events
 

--- a/android/manifest
+++ b/android/manifest
@@ -2,7 +2,7 @@
 # this is your module manifest and used by Titanium
 # during compilation, packaging, distribution, etc.
 #
-version: 2.1.0
+version: 2.2.0
 apiversion: 4
 architectures: arm64-v8a armeabi-v7a x86 x86_64
 description: titanium-web-dialog

--- a/android/src/ti/webdialog/TitaniumWebDialogModule.java
+++ b/android/src/ti/webdialog/TitaniumWebDialogModule.java
@@ -8,6 +8,7 @@
  */
 package ti.webdialog;
 
+import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
 import android.content.pm.ResolveInfo;
@@ -16,10 +17,16 @@ import android.graphics.BitmapFactory;
 import android.graphics.drawable.BitmapDrawable;
 import android.graphics.drawable.Drawable;
 import android.net.Uri;
+import android.os.Bundle;
 import android.util.DisplayMetrics;
 import androidx.browser.customtabs.CustomTabColorSchemeParams;
+import androidx.browser.customtabs.CustomTabsCallback;
+import androidx.browser.customtabs.CustomTabsClient;
 import androidx.browser.customtabs.CustomTabsIntent;
 import androidx.browser.customtabs.CustomTabsService;
+import androidx.browser.customtabs.CustomTabsServiceConnection;
+import androidx.browser.customtabs.CustomTabsSession;
+
 import java.util.ArrayList;
 import java.util.List;
 import org.appcelerator.kroll.KrollDict;
@@ -38,6 +45,52 @@ public class TitaniumWebDialogModule extends KrollModule
 {
 	// Standard Debugging variables
 	private static final String LCAT = "TiWebDialog";
+	private CustomTabsSession mCustomTabsSession;
+	private CustomTabsClient mCustomTabsClient;
+	private CustomTabsServiceConnection mCustomTabsServiceConnection;
+	private String url = "";
+
+	public TitaniumWebDialogModule()
+	{
+		Context context = TiApplication.getAppCurrentActivity();
+
+		mCustomTabsServiceConnection = new CustomTabsServiceConnection() {
+			@Override
+			public void onCustomTabsServiceConnected(ComponentName componentName, CustomTabsClient customTabsClient)
+			{
+				mCustomTabsClient = customTabsClient;
+				mCustomTabsClient.warmup(0L);
+				mCustomTabsSession = mCustomTabsClient.newSession(new CustomTabsCallback() {
+					@Override
+					public void onNavigationEvent(int navigationEvent, Bundle extras)
+					{
+						super.onNavigationEvent(navigationEvent, extras);
+
+						KrollDict event = new KrollDict();
+						if (navigationEvent == TAB_HIDDEN) {
+							event.put("url", url);
+							fireEvent("close", event);
+						}
+					}
+
+					@Override
+					public void extraCallback(String callbackName, Bundle args)
+					{
+						super.extraCallback(callbackName, args);
+					}
+				});
+			}
+
+			@Override
+			public void onServiceDisconnected(ComponentName name)
+			{
+				Log.d(LCAT, "disconnected");
+				mCustomTabsClient = null;
+			}
+		};
+
+		CustomTabsClient.bindCustomTabsService(context, "com.android.chrome", mCustomTabsServiceConnection);
+	}
 
 	private List<String> getCustomTabBrowsers(Context context, List<ResolveInfo> browsersList)
 	{
@@ -60,8 +113,8 @@ public class TitaniumWebDialogModule extends KrollModule
 
 	private void openCustomTab(Context context, List<String> customTabBrowsers, KrollDict options)
 	{
-		String URL = options.getString(Params.URL);
-		CustomTabsIntent.Builder builder = new CustomTabsIntent.Builder();
+		url = options.getString(Params.URL);
+		CustomTabsIntent.Builder builder = new CustomTabsIntent.Builder(mCustomTabsSession);
 		builder.setShowTitle(Utils.getBool(options, Params.SHOW_TITLE));
 
 		int barColor = Utils.getColor(options, Params.BAR_COLOR);
@@ -102,7 +155,7 @@ public class TitaniumWebDialogModule extends KrollModule
 			tabIntent.intent.setPackage(s);
 		}
 
-		tabIntent.launchUrl(context, Uri.parse(URL));
+		tabIntent.launchUrl(context, Uri.parse(url));
 	}
 
 	private Bitmap getIcon(String path)
@@ -157,7 +210,7 @@ public class TitaniumWebDialogModule extends KrollModule
 				openCustomTab(context, customTabBrowsers, options);
 
 			} else {
-				Log.i(Params.LCAT, "No browsers available in this device.");
+				Log.d(Params.LCAT, "No browsers available in this device.");
 			}
 
 			fireEvent("open", event);

--- a/example/app.js
+++ b/example/app.js
@@ -12,7 +12,7 @@ win.add(btnOpenDialog);
 
 btnOpenDialog.addEventListener('click', function () {
 	WebDialog.open({
-		url: 'https://appcelerator.com',
+		url: 'https://tidev.io/',
 		title: 'Hello World',
 
 		// iOS 10+


### PR DESCRIPTION
* add event from https://github.com/tidev/titanium-web-dialog/pull/19 again
* fixed links in Readme
* fixed min. version in Readme
* removed legacy infos from Readme

[ti.webdialog-android-2.2.0.zip](https://github.com/tidev/titanium-web-dialog/files/8358290/ti.webdialog-android-2.2.0.zip)

