### PR TITLE
fix(android): fix uncaught exception when no intent is found

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ In order to use the `close` event on Android it is recommended to have a short d
 * `close` -> `success` (Boolean), `url` (String)
 * `load` -> `success` (Boolean), `url` (String) - iOS only
 * `redirect` -> `url` (String) - iOS only
+* `error` -> `message` (String) - Android only
 
 ### `AuthenticationSession` (iOS only)
 

--- a/android/manifest
+++ b/android/manifest
@@ -2,7 +2,7 @@
 # this is your module manifest and used by Titanium
 # during compilation, packaging, distribution, etc.
 #
-version: 2.2.0
+version: 2.2.1
 apiversion: 4
 architectures: arm64-v8a armeabi-v7a x86 x86_64
 description: titanium-web-dialog

--- a/android/src/ti/webdialog/TitaniumWebDialogModule.java
+++ b/android/src/ti/webdialog/TitaniumWebDialogModule.java
@@ -155,7 +155,14 @@ public class TitaniumWebDialogModule extends KrollModule
 			tabIntent.intent.setPackage(s);
 		}
 
-		tabIntent.launchUrl(context, Uri.parse(url));
+		try {
+			tabIntent.launchUrl(context, Uri.parse(url));
+		} catch (Exception e) {
+			KrollDict event = new KrollDict();
+			event.put("message", e.getLocalizedMessage());
+
+			fireEvent("error", event);
+		}
 	}
 
 	private Bitmap getIcon(String path)


### PR DESCRIPTION
Reproducible if Chrome is not installed or you are trying to open a URL like `mailto:test@test.de` without an assigned email client.