### PR TITLE
feat(android): library update, toColor fix

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,4 +1,4 @@
 
 dependencies {
-	implementation 'androidx.browser:browser:1.4.0'
+	implementation 'androidx.browser:browser:1.5.0'
 }

--- a/android/manifest
+++ b/android/manifest
@@ -2,7 +2,7 @@
 # this is your module manifest and used by Titanium
 # during compilation, packaging, distribution, etc.
 #
-version: 2.2.0
+version: 2.3.0
 apiversion: 4
 architectures: arm64-v8a armeabi-v7a x86 x86_64
 description: titanium-web-dialog

--- a/android/src/ti/webdialog/Utils.java
+++ b/android/src/ti/webdialog/Utils.java
@@ -65,7 +65,7 @@ public class Utils
 	public static int getColor(KrollDict options, String key)
 	{
 		if (options.containsKeyAndNotNull(key)) {
-			return TiConvert.toColor((String) options.get(key));
+			return TiConvert.toColor((String) options.get(key), TiApplication.getAppCurrentActivity());
 
 		} else {
 			return getR("color.colorPrimary");


### PR DESCRIPTION
* library update https://developer.android.com/jetpack/androidx/releases/browser#version_15_2
* use non deprecated "toColor(string, activity)" for https://github.com/tidev/titanium_mobile/pull/13273

[ti.webdialog-android-2.3.0.zip](https://github.com/tidev/titanium-web-dialog/files/11396359/ti.webdialog-android-2.3.0.zip)
