### PR TITLE
android: update to 1.8.0

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,4 +1,4 @@
 
 dependencies {
-	implementation 'androidx.browser:browser:1.5.0'
+	implementation 'androidx.browser:browser:1.6.0'
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,4 +1,4 @@
 
 dependencies {
-	implementation 'androidx.browser:browser:1.6.0'
+	implementation 'androidx.browser:browser:1.8.0'
 }

--- a/android/manifest
+++ b/android/manifest
@@ -15,4 +15,4 @@ name: titanium-web-dialog
 moduleid: ti.webdialog
 guid: 1f19cce1-0ad7-4e25-ab3b-0666f54a0a49
 platform: android
-minsdk: 9.0.0
+minsdk: 12.6.0

--- a/android/manifest
+++ b/android/manifest
@@ -2,7 +2,7 @@
 # this is your module manifest and used by Titanium
 # during compilation, packaging, distribution, etc.
 #
-version: 2.3.0
+version: 2.4.0
 apiversion: 4
 architectures: arm64-v8a armeabi-v7a x86 x86_64
 description: titanium-web-dialog


### PR DESCRIPTION
Starting with 1.6.0 it requires minSdk 34! Titanium doesn't support that yet. It's just so we have the PR already and know about the issue :)

Changelog:  https://developer.android.com/jetpack/androidx/releases/browser#1.8.0

```
[ERROR] [GRADLE]      The minCompileSdk (34) specified in a
[ERROR] [GRADLE]      dependency's AAR metadata (META-INF/com/android/build/gradle/aar-metadata.properties)
[ERROR] [GRADLE]      is greater than this module's compileSdkVersion (android-33).
```

[ti.webdialog-android-2.4.0.zip](https://github.com/user-attachments/files/19166166/ti.webdialog-android-2.4.0.zip)

