### PR TITLE
fix(ios): removed unsupported title property

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@ In order to use the `close` event on Android it is recommended to have a short d
     * `animated` (Boolean, iOS only)
     * `entersReaderIfAvailable` (Boolean, iOS only)
     * `barCollapsingEnabled` (Boolean)
-    * `title` (String, iOS only)
     * `tintColor` (String, iOS only)
     * `dismissButtonStyle` (`DISMISS_BUTTON_STYLE_*`, iOS only)
     * `showTitle` (Boolean, Android only)

--- a/apidoc/WebDialog.yml
+++ b/apidoc/WebDialog.yml
@@ -42,7 +42,7 @@ description: |
     ``` javascript
     if (dialog.isSupported()) {
         dialog.open({
-            url: 'https://appcelerator.com'
+            url: 'https://titaniumsdk.com'
         });
     }
     ```
@@ -92,8 +92,7 @@ methods:
         var dialog = require('ti.webdialog');
         if (dialog.isSupported()) {
             dialog.open({
-                url: 'https://appcelerator.com',
-                title: 'Hello World',
+                url: 'https://titaniumsdk.com',
                 tintColor: 'red'
             });
         }
@@ -168,12 +167,6 @@ properties:
     summary: Indicates if the reader version of content should be shown automatically.
     optional: true
     type: Boolean
-    platforms: [iphone, ipad]
-
-  - name: title
-    summary: The URL to be opened.
-    optional: true
-    type: String
     platforms: [iphone, ipad]
 
   - name: tintColor

--- a/ios/Classes/TiWebdialogModule.m
+++ b/ios/Classes/TiWebdialogModule.m
@@ -146,10 +146,6 @@
 
   SFSafariViewController *safari = [self safariController:_url withEntersReaderIfAvailable:entersReaderIfAvailable andBarCollapsingEnabled:barCollapsingEnabled];
 
-  if ([args objectForKey:@"title"]) {
-    [safari setTitle:[TiUtils stringValue:@"title" properties:args]];
-  }
-
   if ([args objectForKey:@"tintColor"]) {
     TiColor *newColor = [TiUtils colorValue:@"tintColor" properties:args];
     [safari setPreferredControlTintColor:[newColor _color]];


### PR DESCRIPTION
Fixes #11.

**Description:**

- [SFSafariViewController](https://developer.apple.com/documentation/safariservices/sfsafariviewcontroller?language=objc) ignores `setTitle:` of its parent class [UIViewController](https://developer.apple.com/documentation/uikit/uiviewcontroller/title?language=objc), the URL is always displayed as title.
  - therefore, `title` property removed
- BTW replaced outdated URL `appcelerator.com` 


